### PR TITLE
Add a python script to build, run and setup and tear down ip tables rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM debian:jessie
 RUN apt-get -q update
 RUN apt-get -qy install squid3
-RUN apt-get -qy install iptables
 RUN apt-get -qy install python
 RUN echo "http_port 3129 intercept" >> /etc/squid3/squid.conf
 RUN echo "maximum_object_size 1024 MB" >> /etc/squid3/squid.conf
@@ -10,5 +9,5 @@ RUN sed -i "s/^#acl localnet/acl localnet/" /etc/squid3/squid.conf
 RUN sed -i "s/^#http_access allow localnet/http_access allow localnet/" /etc/squid3/squid.conf
 RUN mkdir -p /var/cache/squid3
 RUN chown -R proxy:proxy /var/cache/squid3
-ADD deploy.py /tmp/deploy.py
-CMD /tmp/deploy.py
+ADD deploy_squid.py /tmp/deploy_squid.py
+CMD /tmp/deploy_squid.py

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ will pass along to the corporate proxy.
 docker run --net host --privileged jpetazzo/squid-in-a-can
 ```
 
+
+Checkout this repository: 
+install fig and docker
+
+```
+fig up -d squid && fig run tproxy
+```
+
+
 That's it. Now all HTTP requests going through your Docker host will be
 transparently routed through the proxy running in the container.
 

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,16 @@
+squid:
+  build: .
+  environment:
+    DISK_CACHE_SIZE: 5000
+    MAX_CACHE_OBJECT: 1000
+  net: "host"
+  ## Uncomment and update /path/to/cache
+  #volumes:
+  #- /path/to/cache:/var/cache/squid3
+
+tproxy:
+  build: iptables_docker/.
+  net: "host"
+  privileged: true
+  links:
+  - squid

--- a/iptables_docker/Dockerfile
+++ b/iptables_docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:jessie
+RUN apt-get -q update
+RUN apt-get -qy install iptables
+RUN apt-get -qy install python
+ADD deploy.py /tmp/deploy.py
+CMD /tmp/deploy.py

--- a/iptables_docker/deploy.py
+++ b/iptables_docker/deploy.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2014, Tully Foote
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+import os
+import subprocess
+import socket
+import sys
+import time
+
+redirect_cmd = "iptables -t nat -A PREROUTING -p tcp" \
+               " --dport 80 -j REDIRECT --to 3129 -w"
+remove_redirect_cmd = redirect_cmd.replace(' -A ', ' -D ')
+
+LOCAL_PORT = 3128
+
+
+def is_port_open(port_num):
+    """ Detect if a port is open on localhost"""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    return sock.connect_ex(('127.0.0.1', port_num)) == 0
+
+
+class RedirectContext:
+    """ A context to make sure that the iptables rules are removed
+    after they are inserted."""
+    def __enter__(self):
+        print("Enabling IPtables forwarding: '%s'" % redirect_cmd)
+        try:
+            subprocess.check_call(redirect_cmd.split())
+            self.setup = True
+        except:
+            print("Failed to setup IPTABLES. Did you use --privileged"
+                  " if not you need to run [[%s]]" % redirect_cmd)
+            self.setup = False
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self.setup:
+            print("Disabling IPtables forwarding: '%s'" % remove_redirect_cmd)
+            subprocess.check_call(remove_redirect_cmd.split())
+
+
+def main():
+    if os.geteuid() != 0:
+        print("This must be run as root, aborting")
+        return -1
+
+    # While the process is running wait for squid to be running
+    while not is_port_open(LOCAL_PORT):
+        print("Waiting for port %s to open" % LOCAL_PORT)
+        time.sleep(1)
+
+    if is_port_open(LOCAL_PORT):
+        print("Port %s detected open setting up IPTables redirection" %
+              LOCAL_PORT)
+        with RedirectContext():
+            # Wait for the squid instance to end or a ctrl-c
+            try:
+                while is_port_open(LOCAL_PORT):
+                    time.sleep(1)
+            except KeyboardInterrupt as ex:
+                # Catch Ctrl-C and pass it into the squid instance
+                print("CTRL-C caught, shutting down.")
+            except Exception as ex:
+                print("Caught exception, %s, shutting down" % ex)
+
+    else:
+        print("Port %s never opened, squid instance"
+              " must have terminated prematurely" % LOCAL_PORT)
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This provides a single entry point and takes care of both setup and cleanup of the iptables rules. 

It's super convenient in that it will build local tweaks, and setup the iptables rules and strip them off when shutting down. 

It would be great to get feedback on this. I can polish it up and add documentation if you're interested in merging. 

I've also got a variant which enables the disk caching as it's very useful when using docker heavily for similar repeated tasks which is why I'm using local checkouts instead of the prebuilt image. I'll try to find a way to parameterize that too for submission back. 
