### PR TITLE
Add the ability to append arbitrary squid directives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM debian:jessie
 RUN apt-get -q update && apt-get -qy install python squid3
-RUN echo "http_port 3129 intercept" >> /etc/squid3/squid.conf
 RUN sed -i "s/^#acl localnet/acl localnet/" /etc/squid3/squid.conf
 RUN sed -i "s/^#http_access allow localnet/http_access allow localnet/" /etc/squid3/squid.conf
 RUN mkdir -p /var/cache/squid3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM debian:jessie
-RUN apt-get -q update
-RUN apt-get -qy install squid3
-RUN apt-get -qy install python
+RUN apt-get -q update && apt-get -qy install python squid3
 RUN echo "http_port 3129 intercept" >> /etc/squid3/squid.conf
 RUN echo "maximum_object_size 1024 MB" >> /etc/squid3/squid.conf
 RUN echo "cache_dir ufs /var/cache/squid3 5000 16 256" >> /etc/squid3/squid.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM debian:jessie
 RUN apt-get -q update && apt-get -qy install python squid3
 RUN echo "http_port 3129 intercept" >> /etc/squid3/squid.conf
-RUN echo "maximum_object_size 1024 MB" >> /etc/squid3/squid.conf
-RUN echo "cache_dir ufs /var/cache/squid3 5000 16 256" >> /etc/squid3/squid.conf
 RUN sed -i "s/^#acl localnet/acl localnet/" /etc/squid3/squid.conf
 RUN sed -i "s/^#http_access allow localnet/http_access allow localnet/" /etc/squid3/squid.conf
 RUN mkdir -p /var/cache/squid3

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ will pass along to the corporate proxy.
 
 You can use the squid proxy directly via docker and iptables rules, there is
 also a `fig.yml` for convenience to use fig to launch the system. For more
-information on tuning parameters see below. 
+information on tuning parameters see below.
 
 ### Using Docker and iptables directly.
 
@@ -116,6 +116,13 @@ standard web content it is valuable to increase this size. Use the
 
 The squid disk cache size can be tuned. use
 `-e DISK_CACHE_SIZE=5000` to set the disk cache size (in MB)
+
+### REFRESH_PATTERN
+
+This allows you to override the default refresh_pattern rules. It is a `\n`
+separated list each `\n` will create a new refresh_pattern entry.
+
+[Squid refresh_pattern documentation](http://www.squid-cache.org/Doc/config/refresh_pattern/)
 
 ### Persistent Cache
 

--- a/README.md
+++ b/README.md
@@ -117,12 +117,14 @@ standard web content it is valuable to increase this size. Use the
 The squid disk cache size can be tuned. use
 `-e DISK_CACHE_SIZE=5000` to set the disk cache size (in MB)
 
-### REFRESH_PATTERN
+### SQUID_DIRECTIVES_ONLY
 
-This allows you to override the default refresh_pattern rules. It is a `\n`
-separated list each `\n` will create a new refresh_pattern entry.
+The contents of squid.conf will only be what's defined in SQUID_DIRECTIVES
+giving the user full control of squid.
 
-[Squid refresh_pattern documentation](http://www.squid-cache.org/Doc/config/refresh_pattern/)
+### SQUID_DIRECTIVES
+This will append any contents of the environment variable to squid.conf.
+It is expected that you will use multi-line block quote for the contents.
 
 ### Persistent Cache
 

--- a/deploy_squid.py
+++ b/deploy_squid.py
@@ -39,14 +39,21 @@ def main():
 
     max_object_size = os.getenv("MAXIMUM_CACHE_OBJECT", '1024')
     disk_cache_size = os.getenv("DISK_CACHE_SIZE", '5000')
+    refresh_pattern = os.getenv("REFRESH_PATTERN", None)
 
-    print("Setting MAXIMUM_OBJECT_SIZE %s" % max_object_size)
-    print("Setting DISK_CACHE_SIZE %s" % disk_cache_size)
+    squid_conf_entries = []
+    squid_conf_entries.append('maximum_object_size %s MB\n' % max_object_size)
+    squid_conf_entries.append('cache_dir ufs /var/cache/squid3 %s 16 256\n' %
+                              disk_cache_size)
+
+    if refresh_pattern:
+        for pattern in refresh_pattern.split(';'):
+            squid_conf_entries.append('refresh_pattern %s\n' % pattern)
 
     with open("/etc/squid3/squid.conf", 'a') as conf_fh:
-        conf_fh.write('maximum_object_size %s MB\n' % max_object_size)
-        conf_fh.write('cache_dir ufs /var/cache/squid3 %s 16 256\n' %
-                      disk_cache_size)
+        for conf in squid_conf_entries:
+            print("Appending to squid.conf: [%s]" % conf)
+            conf_fh.write(conf)
 
     # Setup squid directories
     # Reassert permissions in case of mounting from outside

--- a/deploy_squid.py
+++ b/deploy_squid.py
@@ -42,6 +42,7 @@ def main():
     refresh_pattern = os.getenv("REFRESH_PATTERN", None)
 
     squid_conf_entries = []
+    squid_conf_entries.append('http_port 3129 intercept\n')
     squid_conf_entries.append('maximum_object_size %s MB\n' % max_object_size)
     squid_conf_entries.append('cache_dir ufs /var/cache/squid3 %s 16 256\n' %
                               disk_cache_size)

--- a/fig.yml
+++ b/fig.yml
@@ -3,10 +3,9 @@ squid:
   environment:
     DISK_CACHE_SIZE: 5000
     MAX_CACHE_OBJECT: 1000
-    # default if unset
-    # REFRESH_PATTERN: '^ftp:		1440	20%	10080;^gopher:	1440	0%	1440;-i (/cgi-bin/|\?) 0	0%	0;.		0	20%	4320'
-    # agressive for dynamic systems
-    # REFRESH_PATTERN: '. 0 0 1 refresh-ims'
+    # SQUID_DIRECTIVES_ONLY: true
+    # SQUID_DIRECTIVES: |
+    #   refresh_pattern . 0 0 1 refresh-ims
   net: "host"
   ## Uncomment and update /path/to/cache
   #volumes:

--- a/fig.yml
+++ b/fig.yml
@@ -3,6 +3,10 @@ squid:
   environment:
     DISK_CACHE_SIZE: 5000
     MAX_CACHE_OBJECT: 1000
+    # default if unset
+    # REFRESH_PATTERN: '^ftp:		1440	20%	10080;^gopher:	1440	0%	1440;-i (/cgi-bin/|\?) 0	0%	0;.		0	20%	4320'
+    # agressive for dynamic systems
+    # REFRESH_PATTERN: '. 0 0 1 refresh-ims'
   net: "host"
   ## Uncomment and update /path/to/cache
   #volumes:

--- a/iptables_docker/Dockerfile
+++ b/iptables_docker/Dockerfile
@@ -1,6 +1,4 @@
 FROM debian:jessie
-RUN apt-get -q update
-RUN apt-get -qy install iptables
-RUN apt-get -qy install python
+RUN apt-get -q update && apt-get -qy install iptables python
 ADD deploy.py /tmp/deploy.py
 CMD /tmp/deploy.py


### PR DESCRIPTION
Arbitrary directives can be added via SQUID_DIRECTIVES environment variable. And if appending is not enough control ONLY_SQUID_DIRECTIVES enables you to overwrite squid.conf instead of appending. 

There are a few cleanup commits as well for best practices like collapsing apt-get update and apt-get install onto the same lines to keep them atomic. And removing duplicate conf declarations. 

This is useful for tuning more cache parameters. We have a use case which needs more control of the cache at: https://github.com/ros-infrastructure/buildfarm_deployment/issues/41