### PR TITLE
Reduce image size and enable clean exit with docker-compose

### DIFF
--- a/iptables_docker/Dockerfile
+++ b/iptables_docker/Dockerfile
@@ -1,4 +1,13 @@
 FROM debian:jessie
-RUN apt-get -q update && apt-get -qy install iptables python
+RUN apt-get -q update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends iptables python curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    curl -sL --insecure -o /bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.0.1/dumb-init_1.0.1_amd64 && \
+    chmod +x /bin/dumb-init
+
 ADD deploy.py /tmp/deploy.py
-CMD /tmp/deploy.py
+
+ENTRYPOINT ["/bin/dumb-init"]
+
+# Use unbuffered IO so output displays in docker-compose
+CMD ["python", "-u", "/tmp/deploy.py"]

--- a/iptables_docker/deploy.py
+++ b/iptables_docker/deploy.py
@@ -26,6 +26,7 @@ import subprocess
 import socket
 import sys
 import time
+import signal
 
 redirect_cmd = "iptables -t nat -A PREROUTING -p tcp" \
                " --dport 80 -j REDIRECT --to 3129 -w"
@@ -73,10 +74,20 @@ def main():
     if is_port_open(LOCAL_PORT):
         print("Port %s detected open setting up IPTables redirection" %
               LOCAL_PORT)
+
+        # need dict to allow inner function to assign to outer scope variable
+        status = {'shutting_down': False}
+
+        def graceful_shutdown(signal, frame):
+            """Clean shutdown"""
+            print("SIGTERM caught, shutting down.")
+            status["shutting_down"] = True
+
         with RedirectContext():
             # Wait for the squid instance to end or a ctrl-c
+            signal.signal(signal.SIGTERM, graceful_shutdown)
             try:
-                while is_port_open(LOCAL_PORT):
+                while is_port_open(LOCAL_PORT) and status["shutting_down"] is False:
                     time.sleep(1)
             except KeyboardInterrupt as ex:
                 # Catch Ctrl-C and pass it into the squid instance

--- a/squid/Dockerfile
+++ b/squid/Dockerfile
@@ -1,8 +1,18 @@
 FROM debian:jessie
-RUN apt-get -q update && apt-get -qy install python squid3
-RUN sed -i "s/^#acl localnet/acl localnet/" /etc/squid3/squid.conf
-RUN sed -i "s/^#http_access allow localnet/http_access allow localnet/" /etc/squid3/squid.conf
-RUN mkdir -p /var/cache/squid3
-RUN chown -R proxy:proxy /var/cache/squid3
+RUN apt-get -q update && \
+    apt-get -qy --no-install-recommends install python squid3 curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    sed -i "s/^#acl localnet/acl localnet/" /etc/squid3/squid.conf && \
+    sed -i "s/^#http_access allow localnet/http_access allow localnet/" /etc/squid3/squid.conf && \
+    mkdir -p /var/cache/squid3 && \
+    chown -R proxy:proxy /var/cache/squid3 && \
+    curl -sL --insecure -o /bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.0.1/dumb-init_1.0.1_amd64 && \
+    chmod +x /bin/dumb-init
+
 ADD deploy_squid.py /tmp/deploy_squid.py
-CMD /tmp/deploy_squid.py
+
+ENTRYPOINT ["/bin/dumb-init"]
+
+# Use unbuffered IO so output displays in docker-compose
+CMD ["python", "-u", "/tmp/deploy_squid.py"]


### PR DESCRIPTION
First many thanks because this project has allowed me to remove my site specific dockerfile hacks that I needed to reuse local packages.

These patches were tested with docker compose 1.7 and docker 1.11. I found that the iptables rules where not being cleaned up properly. I tracked it down to the python script not receiving the SIGTERM. So I added dumb-init, cleaned up the dockerfile and fixed the deploy script to handle the sigterm.