### PR TITLE
Use foreground mode to build cache folders.

### DIFF
--- a/squid/deploy_squid.py
+++ b/squid/deploy_squid.py
@@ -28,7 +28,7 @@ import sys
 import time
 
 prepare_cache_cmd = "chown -R proxy:proxy /var/cache/squid3"
-build_cmd = "squid3 -z"
+build_cmd = "squid3 -Nz"
 squid_cmd = "squid3 -N"
 
 
@@ -70,9 +70,6 @@ def main():
     # Reassert permissions in case of mounting from outside
     subprocess.check_call(prepare_cache_cmd, shell=True)
     subprocess.check_call(build_cmd, shell=True)
-
-    # wait for the above non-blockin call to finish setting up the directories
-    time.sleep(5)
 
     # Start the squid instance as a subprocess
     squid_in_a_can = subprocess.Popen(squid_cmd, shell=True)


### PR DESCRIPTION
The hard-coded 5-second time.sleep is not always enough time to
initialize the caches, especially on slow-ish drives (resource-limited
ec2 nodes and the like).

This commit removes the time.sleep call and instead passes the -N flag
to the initial `squid -z`, so that it runs synchronously.