### PR TITLE
Port code to debian:trixie

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ squid:
         # - "SQUID_DIRECTIVES='refresh_pattern . 0 0 1 refresh-ims'"
     net: "host"
     ## Uncomment and update /path/to/cache
-    # volumes:
-    #   - /path/to/cache:/var/cache/squid3
+    volumes:
+       - /var/cache/squid:/var/cache/squid
 
 tproxy:
     build: iptables_docker/.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,21 @@
-squid:
+version: '3.8'
+
+services:
+  squid:
     build: squid/.
     environment:
-        - "DISK_CACHE_SIZE=5000"
-        - "MAX_CACHE_OBJECT=1000"
-        # - "SQUID_DIRECTIVES_ONLY=true"
-        # - "SQUID_DIRECTIVES='refresh_pattern . 0 0 1 refresh-ims'"
-    net: "host"
-    ## Uncomment and update /path/to/cache
+      - "DISK_CACHE_SIZE=5000"
+      - "MAX_CACHE_OBJECT=1000"
+      # - "SQUID_DIRECTIVES_ONLY=true"
+      # - "SQUID_DIRECTIVES='refresh_pattern . 0 0 1 refresh-ims'"
+    network_mode: "host"
     volumes:
-       - /var/cache/squid:/var/cache/squid
+      - squid_cache:/var/cache/squid
 
-tproxy:
+  tproxy:
     build: iptables_docker/.
-    net: "host"
+    network_mode: "host"
     privileged: true
+
+volumes:
+  squid_cache:

--- a/iptables_docker/Dockerfile
+++ b/iptables_docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:buster
 RUN apt-get -q update && \
     DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends iptables python curl && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \

--- a/iptables_docker/Dockerfile
+++ b/iptables_docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:buster
+FROM debian:trixie
 RUN apt-get -q update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends iptables python curl && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends iptables python3 curl && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     curl -sL --insecure -o /bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.0.1/dumb-init_1.0.1_amd64 && \
     chmod +x /bin/dumb-init
@@ -10,4 +10,4 @@ ADD deploy.py /tmp/deploy.py
 ENTRYPOINT ["/bin/dumb-init"]
 
 # Use unbuffered IO so output displays in docker-compose
-CMD ["python", "-u", "/tmp/deploy.py"]
+CMD ["python3", "-u", "/tmp/deploy.py"]

--- a/iptables_docker/deploy.py
+++ b/iptables_docker/deploy.py
@@ -32,7 +32,7 @@ redirect_cmd = "iptables -t nat -A PREROUTING -p tcp" \
                " --dport 80 -j REDIRECT --to 3129 -w"
 remove_redirect_cmd = redirect_cmd.replace(' -A ', ' -D ')
 
-LOCAL_PORT = 3128
+LOCAL_PORT = 3129
 
 
 def is_port_open(port_num):

--- a/squid/Dockerfile
+++ b/squid/Dockerfile
@@ -1,13 +1,13 @@
-FROM debian:jessie
+FROM debian:buster
 RUN apt-get -q update && \
     apt-get -qy --no-install-recommends install python squid3 curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-RUN sed -i "s/^#acl localnet/acl localnet/" /etc/squid3/squid.conf
-RUN sed -i "s/^#http_access allow localnet/http_access allow localnet/" /etc/squid3/squid.conf
-RUN mkdir -p /var/cache/squid3
-RUN mv /etc/squid3/squid.conf /etc/squid3/squid.conf.in
-RUN chown -R proxy:proxy /var/cache/squid3
+RUN sed -i "s/^#acl localnet/acl localnet/" /etc/squid/squid.conf
+RUN sed -i "s/^#http_access allow localnet/http_access allow localnet/" /etc/squid/squid.conf
+RUN mkdir -p /var/cache/squid
+RUN mv /etc/squid/squid.conf /etc/squid/squid.conf.in
+RUN chown -R proxy:proxy /var/cache/squid
 RUN curl -sL --insecure -o /bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.0.1/dumb-init_1.0.1_amd64
 RUN chmod +x /bin/dumb-init
 ADD deploy_squid.py /tmp/deploy_squid.py

--- a/squid/Dockerfile
+++ b/squid/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:buster
+FROM debian:trixie
 RUN apt-get -q update && \
-    apt-get -qy --no-install-recommends install python squid3 curl && \
+    apt-get -qy --no-install-recommends install python3 squid curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-RUN sed -i "s/^#acl localnet/acl localnet/" /etc/squid/squid.conf
-RUN sed -i "s/^#http_access allow localnet/http_access allow localnet/" /etc/squid/squid.conf
+RUN sed -i "s/^# acl localnet/acl localnet/" /etc/squid/squid.conf
+RUN sed -i "s/^# http_access allow localnet/http_access allow localnet/" /etc/squid/squid.conf
 RUN mkdir -p /var/cache/squid
 RUN mv /etc/squid/squid.conf /etc/squid/squid.conf.in
 RUN chown -R proxy:proxy /var/cache/squid
@@ -15,4 +15,4 @@ ADD deploy_squid.py /tmp/deploy_squid.py
 ENTRYPOINT ["/bin/dumb-init"]
 
 # Use unbuffered IO so output displays in docker-compose
-CMD ["python", "-u", "/tmp/deploy_squid.py"]
+CMD ["python3", "-u", "/tmp/deploy_squid.py"]

--- a/squid/deploy_squid.py
+++ b/squid/deploy_squid.py
@@ -27,9 +27,9 @@ import socket
 import sys
 import time
 
-prepare_cache_cmd = "chown -R proxy:proxy /var/cache/squid3"
-build_cmd = "squid3 -Nz"
-squid_cmd = "squid3 -N"
+prepare_cache_cmd = "chown -R proxy:proxy /var/cache/squid"
+build_cmd = "squid -Nz"
+squid_cmd = "squid -N"
 
 
 def main():
@@ -38,8 +38,8 @@ def main():
         return -1
 
     # clean up any stale pid files
-    if os.path.exists("/run/squid3.pid"):
-        os.remove("/run/squid3.pid")
+    if os.path.exists("/run/squid.pid"):
+        os.remove("/run/squid.pid")
 
     max_object_size = os.getenv("MAXIMUM_CACHE_OBJECT", '1024')
     disk_cache_size = os.getenv("DISK_CACHE_SIZE", '5000')
@@ -49,13 +49,13 @@ def main():
     squid_conf_entries = []
     squid_conf_entries.append('http_port 3129 intercept')
     squid_conf_entries.append('maximum_object_size %s MB' % max_object_size)
-    squid_conf_entries.append('cache_dir ufs /var/cache/squid3 %s 16 256' %
+    squid_conf_entries.append('cache_dir ufs /var/cache/squid %s 16 256' %
                               disk_cache_size)
 
-    with open("/etc/squid3/squid.conf", 'w') as conf_fh:
+    with open("/etc/squid/squid.conf", 'w') as conf_fh:
 
         if not squid_directives_only:
-            with open("/etc/squid3/squid.conf.in", "r") as preconf:
+            with open("/etc/squid/squid.conf.in", "r") as preconf:
                 conf_fh.write(preconf.read())
             for conf in squid_conf_entries:
                 print("Appending to squid.conf: [%s]" % conf)


### PR DESCRIPTION
I've used these containers for a long time but suddenly they stopped working. Re-building them didn't work as the mirrors for these old distros are not online anymore.

So to fix it, I've used the fork from @kalikaneko and ported it to debian:trixie. For now everything seems to work again :)